### PR TITLE
fixed reupload bug

### DIFF
--- a/gateway/utils/search.utils.ts
+++ b/gateway/utils/search.utils.ts
@@ -75,6 +75,12 @@ const extractSearchResults = async (
         return {};
       }
       const manga_id = imageHref.split("-").pop();
+      const prefetchedSeries = getSeries(manga_id);
+      if (prefetchedSeries) {
+        console.log("prefetched series:", manga_id);
+        return prefetchedSeries;
+      }
+      //series not parsed
       await parseSeries(manga_id);
       return await getSeries(manga_id);
     });


### PR DESCRIPTION
When calling the home page from the client which subsequently calls the three types of fetch manga list methods. The series end up getting reuploaded to the database.


The issue was solved by adding a prefetch step